### PR TITLE
Fixed IPv6 address and port regex matching

### DIFF
--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -13,7 +13,7 @@ from .exceptions import (
     EasySNMPNoSuchObjectError,
     EasySNMPNoSuchInstanceError,
 )
-from .utils import hostname_is_IPv6
+from .utils import hostname_is_IPv4, hostname_is_IPv6, process_connection_string
 from .variables import SNMPVariable, SNMPVariableList
 
 # Mapping between security level strings and their associated integer values.
@@ -204,23 +204,12 @@ class Session(object):
         abort_on_nonexistent=False,
     ):
 
-        # Validate and extract the remote port
-        connection_string = re.match(
-            r"^((?:tcp|udp)6?:)?\s*([^\s]+?)\s*\]?\s*(?:\:(\d+))?$", hostname)
-        if connection_string:
-            if remote_port:
-                raise ValueError(
-                    "a remote port was specified yet the hostname appears "
-                    "to have a port defined too"
-                )
-            else:
-                full_address, hostname, remote_port = connection_string.groups()
-                if ":" in hostname and not hostname_is_IPv6(hostname):
-                    raise ValueError(
-                        "an invalid IPv6 address was specified"
-                    )
-                hostname = full_address
-                remote_port = int(remote_port)
+        if hostname_is_IPv4(hostname):
+            hostname, remote_port = process_connection_string(hostname, remote_port, False)
+            print(f"--------------------{hostname}--------------------")
+        elif hostname_is_IPv6(hostname):
+            hostname, remote_port = process_connection_string(hostname, remote_port, True)
+            print(f"--------------------{hostname}--------------------")
 
         self.hostname = hostname
         self.version = version

--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -206,10 +206,8 @@ class Session(object):
 
         if hostname_is_IPv4(hostname):
             hostname, remote_port = process_connection_string(hostname, remote_port, False)
-            print(f"--------------------{hostname}--------------------")
         elif hostname_is_IPv6(hostname):
             hostname, remote_port = process_connection_string(hostname, remote_port, True)
-            print(f"--------------------{hostname}--------------------")
 
         self.hostname = hostname
         self.version = version

--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -206,7 +206,7 @@ class Session(object):
 
         # Validate and extract the remote port
         connection_string = re.match(
-            r"^((?:tcp6?:|udp6?:)?\[?([^\[\]]+?)\]?)\:(\d+)$", hostname)
+            r"^((?:tcp|udp)6?:)?\s*([^\s]+?)\s*\]?\s*(?:\:(\d+))?$", hostname)
         if connection_string:
             if remote_port:
                 raise ValueError(

--- a/easysnmp/utils.py
+++ b/easysnmp/utils.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, absolute_import
 
 import ipaddress
 import string
+import re
 
 from .compat import ub, text_type
 
@@ -48,6 +49,15 @@ def tostr(value):
         return ub(value)
 
 
+def hostname_is_IPv4(hostname):
+    try:
+        ipaddress.IPv4Address(hostname)
+    except ipaddress.AddressValueError:
+        return False
+    else:
+        return True
+
+
 def hostname_is_IPv6(hostname):
     try:
         ipaddress.IPv6Address(hostname)
@@ -55,3 +65,24 @@ def hostname_is_IPv6(hostname):
         return False
     else:
         return True
+
+
+# Use a different regex in case it needs to detect IPv4 or IPv6 and with or without port.
+# Expected format for IPv6: [2001:db8:1234:5678::1]:22
+def process_connection_string(hostname, remote_port, is_ipv6):
+    connection_string_regex = r"^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::(\d{1,5}))?$" if not is_ipv6 else r"(?:\[)?([:\w.]+)(?:\])?(?::(\d+))?"
+    connection_string = re.match(connection_string_regex, hostname)
+    if connection_string:
+        if remote_port:
+            raise ValueError(
+                "a remote port was specified yet the hostname appears "
+                "to have a port defined too"
+            )
+        else:
+            hostname, remote_port = connection_string.groups()
+            if ":" in hostname and not is_ipv6:
+                raise ValueError(
+                    f"an invalid {'IPv6' if is_ipv6 else 'IPv4'} address was specified"
+                )
+
+    return hostname, remote_port


### PR DESCRIPTION
When trying to call to easysnmp with an IPv6, the next error is shown:

```
2023-11-14 17:21:50,187 [WARNING] (snmp.py:easysnmp_get:484):   Raised SNMP Error - an invalid IPv6 address was specified: 2001:db8:1234:5678::1 - 1.3.6.1.2.1.2.2.1.8.2
UNKNOWN - [Pack Error] EXX-XXXX: ValueError
```
We have tracked it to the connection_string process and to fix it, we have made two different regex strings. Each string will process IPv4 and IPv6 independently. 

To avoid redundancy, we have also refactored connection_string process to a function which is called by the IPv4/IPv6 format check. 